### PR TITLE
use the ckb2021 address format

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@ledgerhq/hw-transport": "^5.9.0",
-    "bech32": "1.1.4",
+    "bech32": "2.0.0",
     "bip32-path": "0.4.2",
     "blake2b-wasm": "2.1.0"
   },

--- a/src/Ckb.js
+++ b/src/Ckb.js
@@ -73,7 +73,7 @@ export default class Ckb {
 
     const addr_contents: number[] = [
       // CKB 2021 address full format prefix
-      ...0x00,
+      0x00,
       // SECP256K1_BLAKE160 code hash
       ...[
         155, 215, 224, 111,  62, 207, 75,

--- a/src/Ckb.js
+++ b/src/Ckb.js
@@ -4,7 +4,7 @@ import type Transport from "@ledgerhq/hw-transport";
 import BIPPath from "bip32-path";
 import * as blockchain from "./annotated";
 import Blake2b from "blake2b-wasm";
-import * as bech32 from "bech32";
+import { bech32m } from "bech32";
 
 /**
  * Nervos API
@@ -71,12 +71,25 @@ export default class Ckb {
         .subarray(0, 20)
     );
 
-    const addr_contents = Buffer.alloc(22);
-    addr_contents.fill("0100", 0, 2, "hex");
-    addr_contents.fill(lockArg, 2, 22);
-    const addr = bech32.encode(
+    const addr_contents: number[] = [
+      // CKB 2021 address full format prefix
+      ...0x00,
+      // SECP256K1_BLAKE160 code hash
+      ...[
+        155, 215, 224, 111,  62, 207, 75,
+        224, 242, 252, 210,  24, 139, 35,
+        241, 185, 252, 200, 142,  93, 75,
+        101, 168,  99, 123,  23, 114, 59,
+        189, 163, 204, 232
+      ],
+      // SECP256K1_BLAKE160 hash type
+      0b0000000_1,
+      // lock args
+      ...lockArg
+    ];
+    const addr = bech32m.encode(
       testnet ? "ckt" : "ckb",
-      bech32.toWords(addr_contents)
+      bech32m.toWords(addr_contents)
     );
 
     return {

--- a/src/Ckb.js
+++ b/src/Ckb.js
@@ -83,7 +83,7 @@ export default class Ckb {
         189, 163, 204, 232
       ],
       // SECP256K1_BLAKE160 hash type
-      0b0000000_1,
+      0b00000001,
       // lock args
       ...lockArg
     ];

--- a/yarn.lock
+++ b/yarn.lock
@@ -1168,10 +1168,10 @@ base@^0.11.1:
     mixin-deep "^1.2.0"
     pascalcase "^0.1.1"
 
-bech32@1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
-  integrity sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==
+bech32@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/bech32/-/bech32-2.0.0.tgz#078d3686535075c8c79709f054b1b226a133b355"
+  integrity sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==
 
 before-after-hook@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
This PR modifies the format of the returning address in `getWalletPublicKey` to CKB2021 from CKB2019 format